### PR TITLE
fixed issue with db not being found in dev environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var ejs = require('ejs');
 const { Pool } = require('pg');
 
 const pool = new Pool({
-    connectionString: process.env.DATABASE_URL,
+    connectionString: process.env.DATABASE_URL || 'postgres://localhost:5432/bnb_test',
 });
 
 var app = express();


### PR DESCRIPTION
Fixed should not need to run the command `export DATABASE_URL=postgres://localhost:5432/bnb_test` every time!